### PR TITLE
Fix coords null in forecast

### DIFF
--- a/example/lib/screens/prebuilt_functions_demo_screen.dart
+++ b/example/lib/screens/prebuilt_functions_demo_screen.dart
@@ -108,7 +108,7 @@ class _PrebuiltFunctionScreenState extends State<PrebuiltFunctionScreen> {
                     mainAxisAlignment: MainAxisAlignment.spaceAround,
                     children: [
                       LocationViewWidget(
-                        title: snapshot.data!.name,
+                        title: snapshot.data!.name ?? '',
                         color: Colors.black,
                       ),
                       WeatherSummary(

--- a/lib/models/weather_data.dart
+++ b/lib/models/weather_data.dart
@@ -21,7 +21,7 @@ class WeatherData {
   Temperature temperature;
   @JsonKey(name: 'coord')
   Coordinates? coordinates;
-  String name;
+  String? name;
   @JsonKey(name: 'dt')
   int date;
 

--- a/lib/models/weather_data.dart
+++ b/lib/models/weather_data.dart
@@ -20,7 +20,7 @@ class WeatherData {
   @JsonKey(name: 'main')
   Temperature temperature;
   @JsonKey(name: 'coord')
-  Coordinates coordinates;
+  Coordinates? coordinates;
   String name;
   @JsonKey(name: 'dt')
   int date;

--- a/lib/models/weather_data.g.dart
+++ b/lib/models/weather_data.g.dart
@@ -13,8 +13,10 @@ WeatherData _$WeatherDataFromJson(Map json) => WeatherData(
       temperature:
           Temperature.fromJson(Map<String, dynamic>.from(json['main'] as Map)),
       wind: Wind.fromJson(Map<String, dynamic>.from(json['wind'] as Map)),
-      coordinates:
-          Coordinates.fromJson(Map<String, dynamic>.from(json['coord'] as Map)),
+      coordinates: json['coord'] == null
+          ? null
+          : Coordinates.fromJson(
+              Map<String, dynamic>.from(json['coord'] as Map)),
       name: json['name'] as String,
       date: json['dt'] as int,
     );
@@ -24,7 +26,7 @@ Map<String, dynamic> _$WeatherDataToJson(WeatherData instance) =>
       'weather': instance.details.map((e) => e.toJson()).toList(),
       'wind': instance.wind.toJson(),
       'main': instance.temperature.toJson(),
-      'coord': instance.coordinates.toJson(),
+      'coord': instance.coordinates?.toJson(),
       'name': instance.name,
       'dt': instance.date,
     };

--- a/lib/models/weather_data.g.dart
+++ b/lib/models/weather_data.g.dart
@@ -17,7 +17,7 @@ WeatherData _$WeatherDataFromJson(Map json) => WeatherData(
           ? null
           : Coordinates.fromJson(
               Map<String, dynamic>.from(json['coord'] as Map)),
-      name: json['name'] as String,
+      name: json['name'] as String?,
       date: json['dt'] as int,
     );
 

--- a/lib/widgets/modules/location_view_widget.dart
+++ b/lib/widgets/modules/location_view_widget.dart
@@ -31,7 +31,7 @@ class LocationView extends StatelessWidget {
           children: [
             Icon(Icons.location_on, color: color, size: 15),
             const SizedBox(width: 10),
-            Text(weatherData.coordinates.lat.toString(),
+            Text(weatherData.coordinates?.lat.toString() ?? '',
                 style: TextStyle(
                   fontSize: 16,
                   color: color,
@@ -41,7 +41,7 @@ class LocationView extends StatelessWidget {
                   fontSize: 16,
                   color: color,
                 )),
-            Text(weatherData.coordinates.lon.toString(),
+            Text(weatherData.coordinates?.lon.toString() ?? '',
                 style: TextStyle(
                   fontSize: 16,
                   color: color,

--- a/lib/widgets/modules/location_view_widget.dart
+++ b/lib/widgets/modules/location_view_widget.dart
@@ -20,7 +20,7 @@ class LocationView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Center(
       child: Column(children: [
-        Text(weatherData.name.toUpperCase(),
+        Text(weatherData.name?.toUpperCase() ?? '',
             style: TextStyle(
               fontSize: 40,
               fontWeight: FontWeight.w300,


### PR DESCRIPTION
It looks like coords and name are not available when requesting the forecast. This fixes it. 

![grafik](https://user-images.githubusercontent.com/15329494/212875367-e24c6917-2565-44ef-a9df-354d715b9501.png)


FIxes #4 